### PR TITLE
Bump max version constraint on actionpack

### DIFF
--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis-store', '>= 1.1.0', '< 2'
   s.add_runtime_dependency 'redis-rack',  '>= 1', '< 3'
-  s.add_runtime_dependency 'actionpack',  '>= 4.0', '< 6'
+  s.add_runtime_dependency 'actionpack',  '>= 4.0', '< 7'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
This change allows this gem to work with Rails 6.